### PR TITLE
Improve floating point handling

### DIFF
--- a/OpenLocationCode/Core.swift
+++ b/OpenLocationCode/Core.swift
@@ -288,9 +288,15 @@ public class OpenLocationCode {
         // Initialize the multipliers to the same value, but they will change according to the dimensions of the grid
         var latPlaceMultiplier = RESOLUTION_STEPS.last!
         var lngPlaceMultiplier = RESOLUTION_STEPS.last!
+        // Adjust to positive range.
+        var adjustedLatitude += LATITUDE_MAX
+        var adjustedLongitude += LONGITUDE_MAX
+        // To avoid problems with floating point, get rid of the degrees.
+        adjustedLatitude = adjustedLatitude.truncatingRemainder(dividingBy: 1.0)
+        adjustedLongitude = adjustedLongitude.truncatingRemainder(dividingBy: 1.0)
         // This is the remainder after we have calculated up to the last RESOLUTION step
-        var adjustedLatitude = (latitude + LATITUDE_MAX).truncatingRemainder(dividingBy: latPlaceMultiplier)
-        var adjustedLongitude = (longitude + LONGITUDE_MAX).truncatingRemainder(dividingBy: lngPlaceMultiplier)
+        adjustedLatitude = adjustedLatitude.truncatingRemainder(dividingBy: latPlaceMultiplier)
+        adjustedLongitude = adjustedLongitude.truncatingRemainder(dividingBy: lngPlaceMultiplier)
         for _ in 0..<codeLenAfterDefaultLen {
             // FP Multiplication is usually less costly than division
             let row = Int((adjustedLatitude * MATRIX_FOR_PLUS_DIM.rows) / latPlaceMultiplier)

--- a/OpenLocationCodeTests/OpenLocationCodeTests.swift
+++ b/OpenLocationCodeTests/OpenLocationCodeTests.swift
@@ -38,6 +38,12 @@ class OpenLocationCodeTests: XCTestCase {
         // should only differ in the last two characters
         let filtered = zip(x!.getCode().characters, y!.getCode().characters).filter{$0 != $1}
         assert(filtered.count <= 2)
+        let z: OpenLocationCode? = try? OpenLocationCode(latitude: 90, longitude: 1, codeLength: 10)
+        assert(z != nil)
+        assert(z?.getCode() == "CFX3X2X2+X2")
+        let a: OpenLocationCode? = try? OpenLocationCode(latitude: 1, longitude: 1 codeLength: 11)
+        assert(a != nil)
+        assert(a?.getCode() == "6FH32222+222")
     }
     
     func testDecode() {


### PR DESCRIPTION
We identified a problem in handling floating point numbers in the core OLC libraries.
See [issue 121](https://github.com/google/open-location-code/issues/121).

This provides the fix, and includes tests for this, and for [issue 118](https://github.com/google/open-location-code/issues/118) which was a segfault in C++ & Dart. (I think you should be ok from that problem but it doesn't hurt to add the test.)

I can't build your code unfortunately so please check that it still works. :-)